### PR TITLE
#7 - AsyncEventHandler documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,29 +28,29 @@ using ZCrew.Extensions.Tasks;
 
 public class NotificationService
 {
-    private readonly IAsyncAction<string> _onNotification;
+    private readonly IAsyncAction<string> onNotification;
 
     // Accept a synchronous callback
     public NotificationService(Action<string> onNotification)
     {
-        _onNotification = onNotification.AsAsyncAction();
+        this.onNotification = onNotification.AsAsyncAction();
     }
 
     // Accept an async callback
     public NotificationService(Func<string, Task> onNotification)
     {
-        _onNotification = onNotification.AsAsyncAction();
+        this.onNotification = onNotification.AsAsyncAction();
     }
 
     // Accept an async callback with cancellation support
     public NotificationService(Func<string, CancellationToken, Task> onNotification)
     {
-        _onNotification = onNotification.AsAsyncAction();
+        this.onNotification = onNotification.AsAsyncAction();
     }
 
     public async Task NotifyAsync(string message, CancellationToken token = default)
     {
-        await _onNotification.InvokeAsync(message, token);
+        await this.onNotification.InvokeAsync(message, token);
     }
 }
 ```
@@ -94,6 +94,9 @@ watcher.FileChanged += async (sender, e, token) =>
 ### Invocation Methods
 
 ```csharp
+// Default: handlers run one after another similar to EventHandler.Invoke
+await FileChanged.InvokeAsync(this, args, token);
+
 // Sequential: handlers run one after another
 await FileChanged.InvokeSequentialAsync(this, args, token);
 

--- a/ZCrew.Extensions.Tasks.slnx
+++ b/ZCrew.Extensions.Tasks.slnx
@@ -1,5 +1,7 @@
 <Solution>
-  <Folder Name="/docs/" />
+  <Folder Name="/docs/">
+    <File Path="docs/AsyncEventHandler.md" />
+  </Folder>
   <Folder Name="/samples/" />
   <Folder Name="/src/">
     <Project Path="src/ZCrew.Extensions.Tasks/ZCrew.Extensions.Tasks.csproj" />

--- a/docs/AsyncEventHandler.md
+++ b/docs/AsyncEventHandler.md
@@ -1,0 +1,155 @@
+# AsyncEventHandler
+
+`AsyncEventHandler` and `AsyncEventHandler<TEventArgs>` are async-compatible delegate types for events, similar to the
+standard `EventHandler` but supporting `async`/`await` patterns. This is accomplished without using `async void` to
+prevent crashing if an exception occurs.
+
+## Overview
+
+```csharp
+public delegate Task AsyncEventHandler(object sender, EventArgs args, CancellationToken token);
+public delegate Task AsyncEventHandler<TEventArgs>(object sender, TEventArgs args, CancellationToken token);
+```
+
+### Example
+
+```csharp
+public class MyService
+{
+    public event AsyncEventHandler<string>? MessageReceived;
+
+    public async Task ProcessMessageAsync(string args, CancellationToken token)
+    {
+        // Invoke all handlers sequentially, collecting any exceptions
+        await MessageReceived.InvokeSequentialAsync(this, args, token);
+    }
+}
+
+// Subscribe to the event
+var service = new MyService();
+service.MessageReceived += async (sender, args, token) =>
+{
+    await SaveToDbAsync(args, token);
+};
+service.MessageReceived += async (sender, args, token) =>
+{
+    await NotifyUsersAsync(args, token);
+};
+```
+
+## Invoke Methods
+
+| Method                  | Execution  | Exception Behavior                              | Cancellation Support                          |
+|-------------------------|------------|-------------------------------------------------|-----------------------------------------------|
+| `InvokeAsync`           | Sequential | First **synchronous** exception stops execution | At the start                                  |
+| `InvokeSequentialAsync` | Sequential | Collects all exceptions, invokes all handlers   | At the start and between each handler         |
+| `InvokeParallelAsync`   | Parallel   | Collects all exceptions, invokes all handlers   | At the start and before starting each handler |
+
+## Exception Handling
+
+### InvokeAsync
+
+Synchronous exceptions thrown by any handler immediately propagate, and the remaining handlers are **not** invoked:
+
+```csharp
+handler += async (sender, args, token) => throw new Exception();
+handler += async (sender, args, token) => await Task.Delay(TimeSpan.FromSeconds(100), token); // Not invoked
+
+// Since the first handler threw an exception synchronously, the second handler will NOT be invoked
+await handler.InvokeAsync(sender, args, token);
+```
+
+However, if the exception is thrown after the handler has yielded or the exception is thrown asynchronously, the
+remaining handlers are invoked:
+
+```csharp
+handler += (sender, args, token) => Task.FromException(new Exception()); // Throw an exception asynchronously
+handler += async (sender, args, token) =>
+{
+    await Task.Delay(TimeSpan.FromSeconds(5), token); // This causes the handler to yield
+    throw new Exception();
+};
+handler += async (sender, args, token) => await Task.Delay(TimeSpan.FromSeconds(100), token); // Invoked!
+
+// Since the first two handlers did not throw an exception synchronously, the third handler will be invoked
+await handler.InvokeAsync(sender, args, token);
+```
+
+### InvokeSequentialAsync / InvokeParallelAsync
+
+These methods collect exceptions from all handlers and throw an `AggregateException` after all handlers have completed:
+
+```csharp
+try
+{
+    await handler.InvokeSequentialAsync(sender, args, token);
+
+    // or...
+
+    await handler.InvokeParallelAsync(sender, args, token);
+}
+catch (AggregateException ex)
+{
+    foreach (var inner in ex.Flatten().InnerExceptions)
+    {
+        Console.WriteLine($"Handler failed: {inner.Message}");
+    }
+}
+```
+
+### Cancellation
+
+All invocation methods check `CancellationToken` before invoking handlers.
+The `InvokeAsync` is the only invocation method that does not check for cancellation **between** handlers in any way.
+When cancellation is requested:
+
+- `OperationCanceledException` is thrown immediately
+- Remaining handlers are **not** invoked
+- Any in-flight exceptions are not wrapped (cancellation takes priority)
+
+```csharp
+try
+{
+    await handler.InvokeSequentialAsync(sender, args, cancellationToken);
+}
+catch (OperationCanceledException)
+{
+    // Cancellation was requested
+}
+```
+
+## Best Practices
+
+### Unsubscribe to Prevent Resource Leaks
+
+Like standard `EventHandler`, always unsubscribe from `AsyncEventHandler` when the subscriber is no longer needed:
+
+```csharp
+// Store the handler reference for later removal
+AsyncEventHandler<string> handler = async (sender, args, token) => { ... };
+
+service.MessageReceived += handler;
+
+// Later, when disposing or cleaning up
+service.MessageReceived -= handler;
+```
+
+### Handler Ordering
+
+When using `InvokeSequentialAsync`, handlers are invoked in registration order.
+However, the exact sequence can be difficult to predict in complex applications where multiple components subscribe to
+the same event at different times.
+If strict ordering is required for publicly accessible event handlers, consider using a dedicated message bus or
+orchestration pattern instead.
+
+Failure to unsubscribe can prevent objects from being garbage collected, leading to memory leaks.
+
+### When to Use Alternatives
+
+`AsyncEventHandler` is suitable for simple pub/sub scenarios within a single application.
+Consider using dedicated solutions for:
+
+- **Complex routing or filtering** - Use an in-memory message bus (e.g., MediatR, MassTransit InMemory)
+- **Cross-process communication** - Use a message broker (e.g., RabbitMQ, Azure Service Bus)
+- **Event sourcing or replay** - Use an event store or event aggregator
+- **Guaranteed delivery** - Use a durable messaging system

--- a/docs/AsyncEventHandler.md
+++ b/docs/AsyncEventHandler.md
@@ -135,6 +135,8 @@ service.MessageReceived += handler;
 service.MessageReceived -= handler;
 ```
 
+Failure to unsubscribe can prevent objects from being garbage collected, leading to memory leaks.
+
 ### Handler Ordering
 
 When using `InvokeSequentialAsync`, handlers are invoked in registration order.
@@ -142,8 +144,6 @@ However, the exact sequence can be difficult to predict in complex applications 
 the same event at different times.
 If strict ordering is required for publicly accessible event handlers, consider using a dedicated message bus or
 orchestration pattern instead.
-
-Failure to unsubscribe can prevent objects from being garbage collected, leading to memory leaks.
 
 ### When to Use Alternatives
 

--- a/docs/AsyncEventHandler.md
+++ b/docs/AsyncEventHandler.md
@@ -39,11 +39,11 @@ service.MessageReceived += async (sender, args, token) =>
 
 ## Invoke Methods
 
-| Method                  | Execution  | Exception Behavior                              | Cancellation Support                          |
-|-------------------------|------------|-------------------------------------------------|-----------------------------------------------|
-| `InvokeAsync`           | Sequential | First **synchronous** exception stops execution | At the start                                  |
-| `InvokeSequentialAsync` | Sequential | Collects all exceptions, invokes all handlers   | At the start and between each handler         |
-| `InvokeParallelAsync`   | Parallel   | Collects all exceptions, invokes all handlers   | At the start and before starting each handler |
+| Method                  | Execution  | Exception Behavior                                 | Cancellation Support                          |
+|-------------------------|------------|----------------------------------------------------|-----------------------------------------------|
+| `InvokeAsync`           | Sequential | **Only the first synchronous exception is thrown** | At the start                                  |
+| `InvokeSequentialAsync` | Sequential | Collects all exceptions, invokes all handlers      | At the start and between each handler         |
+| `InvokeParallelAsync`   | Parallel   | Collects all exceptions, invokes all handlers      | At the start and before starting each handler |
 
 ## Exception Handling
 
@@ -59,16 +59,17 @@ handler += async (sender, args, token) => await Task.Delay(TimeSpan.FromSeconds(
 await handler.InvokeAsync(sender, args, token);
 ```
 
-However, if the exception is thrown after the handler has yielded or the exception is thrown asynchronously, the
-remaining handlers are invoked:
+However, if the exception is thrown asynchronously or an exception-task is returned synchronously using
+`Task.FromException(...)`, the remaining handlers are invoked.
+The exceptions thrown here by the first two handlers will not be observed:
 
 ```csharp
-handler += (sender, args, token) => Task.FromException(new Exception()); // Throw an exception asynchronously
 handler += async (sender, args, token) =>
 {
     await Task.Delay(TimeSpan.FromSeconds(5), token); // This causes the handler to yield
     throw new Exception();
 };
+handler += (sender, args, token) => Task.FromException(new Exception()); // Return an exception-task
 handler += async (sender, args, token) => await Task.Delay(TimeSpan.FromSeconds(100), token); // Invoked!
 
 // Since the first two handlers did not throw an exception synchronously, the third handler will be invoked


### PR DESCRIPTION
Documentation for the `AsyncEventHandler` was added to `/docs/AsyncEventHandler.md`. This helps emphasize the exception behavior, shows some examples, and provides some recommendations for the async event handlers. 

Ideally this should prevent confusion, bugs, and issues by setting expectations clearly and repeatedly. Though, that seldom happens, eh?

Closes #7