### PR TITLE
#20 - Fix issue with NuGet publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -33,7 +33,9 @@ jobs:
         run: dotnet test --configuration Release --no-build --verbosity normal
 
       - name: Pack
-        run: dotnet pack --configuration Release --no-build --output ${{ env.NuGetDirectory }} -p:PackageVersion=${{ github.event.release.tag_name }}
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
+        run: dotnet pack --configuration Release --no-build --output ${{ env.NuGetDirectory }} -p:PackageVersion=${VERSION#v}
 
       - name: NuGet login
         uses: NuGet/login@v1


### PR DESCRIPTION
Strip the `v` character from the start of the tag. So `v1.0.0-preview.1` would have become `1.0.0-preview.1`

Closes #20